### PR TITLE
Only show source if it's usable

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,7 +698,7 @@
         uniqueKeys.forEach(key => {
             const option = document.createElement('option');
             option.value = abbrList[key] ? key + ' (' + abbrList[key] + ')' : key + ' (' + key + ')';
-            sourceList.appendChild(option.cloneNode(true));
+            if (key in routeInfo) sourceList.appendChild(option.cloneNode(true));
             targetList.appendChild(option);
            });
            console.log("Datalists populated.");
@@ -1068,3 +1068,4 @@
   async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
This pull request hides all the redundant trackers that have no routes from the source field.

I find myself scrolling through the list and clicking every tracker I'm in just to realise there's no paths. I believe it'd be better to hide trackers from the source list if they can't be used to join other trackers.