### PR TITLE
Skip redundant paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,7 +710,7 @@
       return Math.max(days1, days2);
     }
 
-    function findAllRoutes(start, end, maxJumps, maxDays) {
+    function findAllRoutes(start, end, selectedSources, maxJumps, maxDays) {
       const result = [];
       const stack = [[start, [start], 0]];
       while (stack.length) {
@@ -721,6 +721,7 @@
           continue;
         }
         for (const [next, _] of Object.entries(routeInfo[node] || {})) {
+		  if (selectedSources.includes(next)) continue;
           const maxDaysToNext = getMaxDays(node, next);
           if (!route.includes(next) && (days + maxDaysToNext) <= maxDays) {
             stack.push([next, [...route, next], days + maxDaysToNext]);
@@ -947,7 +948,7 @@
                   console.log(`Target tracker "${target}" not found in routes for source "${source}".`);
                   return;
               }
-              const routesFromSource = findAllRoutes(source, target, maxJumps, maxDays);
+              const routesFromSource = findAllRoutes(source, target, selectedSources, maxJumps, maxDays);
               combinedRoutes = combinedRoutes.concat(routesFromSource);
           });
 
@@ -1068,3 +1069,4 @@
   async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
When selecting multiple source trackers, redundant paths can appear. This pull request hides redundant paths.

**Example:**

To go from LST to Aither, this is the path:
<img width="1170" height="828" alt="image" src="https://github.com/user-attachments/assets/129782c5-3fc1-4eda-b490-c9efb31c6678" />

And to go from FNP to Aither, there are 4 paths, all routing through LST:
<img width="1170" height="1064" alt="image" src="https://github.com/user-attachments/assets/b966e9f3-40ec-49c7-8421-526b8d6de9eb" />

With this change, when selecting both LST and FNP, all routes starting from FNP that use LST will be ignored as they're redundant:
<img width="1170" height="962" alt="image" src="https://github.com/user-attachments/assets/57faddd2-f1bf-4b88-bb06-bb2d69aff4b6" />
